### PR TITLE
Fix Dockerfile context paths

### DIFF
--- a/agents/hallway_agent/Dockerfile
+++ b/agents/hallway_agent/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY ../../requirements.txt .
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 EXPOSE 8000

--- a/agents/kitchen_agent/Dockerfile
+++ b/agents/kitchen_agent/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY ../../requirements.txt .
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 EXPOSE 8000

--- a/agents/office_agent/Dockerfile
+++ b/agents/office_agent/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY ../../requirements.txt .
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 EXPOSE 8000

--- a/supervisor_agent/Dockerfile
+++ b/supervisor_agent/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY ../requirements.txt .
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- fix Dockerfile `COPY` paths so builds don't fail

## Testing
- `python -m py_compile sensor_reader.py supervisor_agent/supervisor_agent.py agents/kitchen_agent/agent.py agents/hallway_agent/agent.py agents/office_agent/agent.py`
- ❌ `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683fe9c37e50832bb589e477607d9640