### PR TITLE
Fix kitchen agent URL in supervisor

### DIFF
--- a/supervisor_agent/supervisor_agent.py
+++ b/supervisor_agent/supervisor_agent.py
@@ -4,7 +4,11 @@ import uvicorn, os, httpx, asyncio
 app = FastAPI(title="Supervisor Agent")
 
 AGENTS = {
-    "kitchen_agent": "http://192.168.0.107:8000/task",
+    # Internal service URLs for each delegate agent
+    # Use service names defined in docker-compose instead of
+    # hard-coded IP addresses so the agents can communicate in
+    # different deployment environments.
+    "kitchen_agent": "http://kitchen_agent:8000/task",
     "hallway_agent": "http://hallway_agent:8000/task",
     "office_agent": "http://office_agent:8000/task",
 }


### PR DESCRIPTION
## Summary
- use `http://kitchen_agent:8000/task` for the kitchen agent
- document service URLs for agents

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68401ee50724832b8c816b45573d7e25