### PR TITLE
Fix README route reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Each agent auto‑detects the BME680; if the library or sensor isn’t found it 
 ## Customization
 
 * Extend `SensorReader.read()` in `sensor_reader.py` for more sensors.
-* Enhance `SupervisorAgent.route()` for richer delegation (LLM prompt, etc).
+* Enhance `route()` in `supervisor_agent.py` for richer delegation (LLM prompt, etc).
 * Add secure authentication with an API key header before production use.
 
 Enjoy hacking!


### PR DESCRIPTION
## Summary
- update README customization bullet to mention route() in supervisor_agent.py

## Testing
- `python3 -m py_compile supervisor_agent/supervisor_agent.py sensor_reader.py`

------
https://chatgpt.com/codex/tasks/task_e_68401ef0683c832b9c0a39cfce9452d4