### PR TITLE
Fix pluralization in README service table

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo spins up **three sensor‑powered agents**—one per Raspberry Pi—
 
 | Service (Docker)  | Intended host | Role |
 |-------------------|---------------|------|
-| supervisor_agent  | Laptop        | Delegates tasks to RPis |
+| supervisor_agent  | Laptop        | Delegates tasks to RPIs |
 | kitchen_agent     | Kitchen RPi   | Reads BME680, serves data |
 | hallway_agent     | Hallway RPi   | Reads BME680, serves data |
 | office_agent      | Office RPi    | Reads BME680, serves data |


### PR DESCRIPTION
## Summary
- update README to use "RPIs" instead of "RPis" in the service table

## Testing
- `grep -n RPIs README.md`

------
https://chatgpt.com/codex/tasks/task_e_68401ef215a4832b93f11df63a928f97