### PR TITLE
Add web UI for supervisor agent

### DIFF
--- a/supervisor_agent/static/index.html
+++ b/supervisor_agent/static/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Supervisor Agent</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    textarea { width: 100%; height: 100px; }
+    select, button { margin-top: 1em; }
+    pre { background: #f4f4f4; padding: 1em; }
+  </style>
+</head>
+<body>
+  <h1>Supervisor Agent</h1>
+  <textarea id="task" placeholder="Enter your task here"></textarea>
+  <br>
+  <label for="agent">Agent:</label>
+  <select id="agent">
+    <option value="">auto route</option>
+    <option value="kitchen">kitchen</option>
+    <option value="hallway">hallway</option>
+    <option value="office">office</option>
+  </select>
+  <br>
+  <button onclick="sendTask()">Send</button>
+  <pre id="output"></pre>
+  <script>
+    async function sendTask() {
+      const taskText = document.getElementById('task').value;
+      const agent = document.getElementById('agent').value;
+      const body = { task: taskText };
+      if (agent) body.agent = agent;
+      const res = await fetch('/task', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      const data = await res.json();
+      document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+    }
+  </script>
+</body>
+</html>
+

--- a/supervisor_agent/supervisor_agent.py
+++ b/supervisor_agent/supervisor_agent.py
@@ -1,7 +1,10 @@
 from fastapi import FastAPI, Body
+from fastapi.responses import HTMLResponse
+from pathlib import Path
 import uvicorn, os, httpx, asyncio
 
 app = FastAPI(title="Supervisor Agent")
+INDEX_FILE = Path(__file__).resolve().parent / "static" / "index.html"
 
 AGENTS = {
     # Internal service URLs for each delegate agent
@@ -12,6 +15,10 @@ AGENTS = {
     "hallway_agent": "http://hallway_agent:8000/task",
     "office_agent": "http://office_agent:8000/task",
 }
+
+@app.get("/", response_class=HTMLResponse)
+async def ui():
+    return INDEX_FILE.read_text()
 
 def route(task: dict) -> str:
     # Prefer explicit agent field


### PR DESCRIPTION
## Summary
- create minimal HTML interface under supervisor_agent/static
- serve the new page from the supervisor agent using FastAPI

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402080b1b8832b9b291c04fc711e3f