### PR TITLE
Update gguf models via huggingface hub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests
 bme680
 transformers
 llama-cpp-python
+huggingface-hub

--- a/supervisor_agent/llm_models.py
+++ b/supervisor_agent/llm_models.py
@@ -17,30 +17,30 @@ try:
 except Exception:
     Llama = None
 
+try:
+    from huggingface_hub import hf_hub_download
+except Exception:
+    hf_hub_download = None
+
 BASE_CACHE_DIR = os.getenv("HF_HOME", os.path.expanduser("~/.cache/huggingface"))
 
 LLAMA3_ID = "meta-llama/Llama-3.2-1B-Instruct"
 
-TINY_LLAMA_PATH = os.path.join(
-    BASE_CACHE_DIR,
-    "models--TheBloke--TinyLlama-1.1B-Chat-v1.0-GGUF",
-    "snapshots",
-    "52e7645ba7c309695bec7ac98f4f005b139cf465",
-    "tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf",
-)
+TINY_LLAMA_REPO = "TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF"
+TINY_LLAMA_FILE = "tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf"
 
-PHI3_PATH = os.path.join(
-    BASE_CACHE_DIR,
-    "models--microsoft--Phi-3-mini-4k-instruct-gguf",
-    "snapshots",
-    "999f761fe19e26cf1a339a5ec5f9f201301cbb83",
-    "Phi-3-mini-4k-instruct-q4.gguf",
-)
+PHI3_REPO = "microsoft/Phi-3-mini-4k-instruct-gguf"
+PHI3_FILE = "Phi-3-mini-4k-instruct-q4.gguf"
 
 _llama3_model = None
 _llama3_tok = None
 _tinyllama = None
 _phi3 = None
+
+def _download_model(repo: str, filename: str) -> str:
+    if hf_hub_download is None:
+        raise RuntimeError("huggingface-hub not installed")
+    return hf_hub_download(repo_id=repo, filename=filename, cache_dir=BASE_CACHE_DIR)
 
 def _load_llama3():
     global _llama3_model, _llama3_tok
@@ -57,7 +57,8 @@ def _load_tinyllama():
     if _tinyllama is None:
         if Llama is None:
             raise RuntimeError("llama-cpp-python not installed")
-        _tinyllama = Llama(model_path=TINY_LLAMA_PATH)
+        path = _download_model(TINY_LLAMA_REPO, TINY_LLAMA_FILE)
+        _tinyllama = Llama(model_path=path)
     return _tinyllama
 
 
@@ -66,7 +67,8 @@ def _load_phi3():
     if _phi3 is None:
         if Llama is None:
             raise RuntimeError("llama-cpp-python not installed")
-        _phi3 = Llama(model_path=PHI3_PATH)
+        path = _download_model(PHI3_REPO, PHI3_FILE)
+        _phi3 = Llama(model_path=path)
     return _phi3
 
 

--- a/supervisor_agent/requirements.txt
+++ b/supervisor_agent/requirements.txt
@@ -5,3 +5,4 @@ requests
 bme680
 transformers
 llama-cpp-python
+huggingface-hub

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -5,8 +5,23 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import pytest
 from supervisor_agent.llm_models import generate
+from supervisor_agent import llm_models
+from unittest import mock
 
 
 def test_invalid_model():
     with pytest.raises(ValueError):
         generate("badmodel", "hello")
+
+
+def test_load_tinyllama_uses_hf_hub_download():
+    with mock.patch.object(llm_models, "hf_hub_download", return_value="/tmp/x") as dl:
+        with mock.patch.object(llm_models, "Llama") as LlamaMock:
+            llm_models._tinyllama = None
+            llm_models._load_tinyllama()
+            dl.assert_called_once_with(
+                repo_id=llm_models.TINY_LLAMA_REPO,
+                filename=llm_models.TINY_LLAMA_FILE,
+                cache_dir=llm_models.BASE_CACHE_DIR,
+            )
+            LlamaMock.assert_called_once()


### PR DESCRIPTION
## Summary
- load TinyLlama and Phi-3 via `hf_hub_download`
- use new constants for repo IDs and filenames
- add Hugging Face Hub to requirements
- test that `hf_hub_download` is invoked when loading TinyLlama

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684066ee73e4832ba26929838a9e2f77