### PR TITLE
LLM supervisor with prompt tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ docker compose build
 docker compose up -d
 ```
 
-Send a task from Windows CMD / PowerShell:
+Interact with the supervisor by sending a natural language prompt:
 
 ```bash
-curl -X POST "http://localhost:8000/task" ^
-     -H "Content-Type: application/json" ^
-     -d "{\"task\": \"get sensor data from kitchen\"}"
+curl -X POST "http://localhost:8000/prompt" \
+     -H "Content-Type: application/json" \
+     -d '{"prompt":"Get the latest kitchen sensor data"}'
 ```
 
-The supervisor will route the request to **kitchen_agent** and return the latest sensor reading.
+The LLM-based supervisor will parse your prompt, delegate the task to the appropriate agent and return the agent response.
 
 ## Deploying on each RPi
 

--- a/supervisor_agent/static/index.html
+++ b/supervisor_agent/static/index.html
@@ -12,20 +12,7 @@
 </head>
 <body>
   <h1>Supervisor Agent</h1>
-  <textarea id="task" placeholder="Enter your task here"></textarea>
-  <br>
-  <label for="agent">Agent:</label>
-  <select id="agent">
-    <option value="">auto route</option>
-    <option value="kitchen">kitchen</option>
-    <option value="hallway">hallway</option>
-    <option value="office">office</option>
-  </select>
-  <br>
-  <button onclick="sendTask()">Send</button>
-  <pre id="output"></pre>
-  <h2>LLM Chat</h2>
-  <textarea id="prompt" placeholder="Enter prompt"></textarea>
+  <textarea id="prompt" placeholder="Describe your tasks"></textarea>
   <br>
   <label for="model">Model:</label>
   <select id="model">
@@ -41,32 +28,18 @@
   <label for="top_p">Top-p:</label>
   <input id="top_p" type="number" step="0.05" value="0.95" />
   <br>
-  <button onclick="sendPrompt()">Chat</button>
+  <button onclick="sendPrompt()">Send</button>
   <pre id="llm_output"></pre>
   <h2>Agents</h2>
   <ul id="agents"></ul>
   <script>
-    async function sendTask() {
-      const taskText = document.getElementById('task').value;
-      const agent = document.getElementById('agent').value;
-      const body = { task: taskText };
-      if (agent) body.agent = agent;
-      const res = await fetch('/task', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body)
-      });
-      const data = await res.json();
-      document.getElementById('output').textContent = JSON.stringify(data, null, 2);
-    }
-
     async function sendPrompt() {
       const prompt = document.getElementById('prompt').value;
       const model = document.getElementById('model').value;
       const maxTokens = parseInt(document.getElementById('max_tokens').value);
       const temperature = parseFloat(document.getElementById('temperature').value);
       const topP = parseFloat(document.getElementById('top_p').value);
-      const res = await fetch('/llm', {
+      const res = await fetch('/prompt', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -78,7 +51,7 @@
         })
       });
       const data = await res.json();
-      document.getElementById('llm_output').textContent = data.text || data.error || JSON.stringify(data);
+      document.getElementById('llm_output').textContent = JSON.stringify(data, null, 2);
     }
 
     async function refreshAgents() {

--- a/tests/test_supervisor_agent.py
+++ b/tests/test_supervisor_agent.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from supervisor_agent import supervisor_agent as sa
 from supervisor_agent.supervisor_agent import route
 
 
@@ -32,3 +33,19 @@ def test_keyword_detection(text, expected):
 def test_default_office_agent():
     task = {"task": "Go outside and check the garden"}
     assert route(task) == "office_agent"
+
+
+@pytest.mark.asyncio
+async def test_handle_prompt(monkeypatch):
+    def fake_generate(model, prompt, max_tokens=256, temperature=0.7, top_p=0.95):
+        return '[{"task": "Check kitchen sensor"}]'
+
+    async def fake_handle_task(task):
+        assert task["task"] == "Check kitchen sensor"
+        return {"delegate": "kitchen_agent", "agent_response": {"ok": True}}
+
+    monkeypatch.setattr(sa, "generate", fake_generate)
+    monkeypatch.setattr(sa, "handle_task", fake_handle_task)
+
+    result = await sa.handle_prompt({"prompt": "Get kitchen data"})
+    assert result["results"][0]["delegate"] == "kitchen_agent"


### PR DESCRIPTION
## Summary
- add `/prompt` endpoint driven by the LLM
- expose `delegate_task` as a tool for the supervisor
- simplify web UI to single prompt box
- document new usage in README
- test LLM prompt delegation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684068e098ac832b98a4738183884d6e